### PR TITLE
Add informational ref to draft-h3-datagram

### DIFF
--- a/draft-pauly-quic-datagram.md
+++ b/draft-pauly-quic-datagram.md
@@ -174,7 +174,8 @@ Application protocols using datagrams might need to differentiate categories or
 flows of datagrams being transmitted over a single QUIC connection.
 Each application protocol is expected to define its own mechanism for
 adding flow identifiers or similar mechanisms to the datagram payloads
-being sent over the QUIC connection.
+being sent over the QUIC connection. For example, the use of datagrams with
+HTTP/3 is defined in {{?I-D.schinazi-quic-h3-datagram}}.
 
 ## Acknowledgement Handling
 


### PR DESCRIPTION
Now that flow ID has been removed from this draft, add informational reference to its new home.