### PR TITLE
Clarify interaction with 0-RTT

### DIFF
--- a/draft-pauly-quic-datagram.md
+++ b/draft-pauly-quic-datagram.md
@@ -123,6 +123,17 @@ strictly larger than the value it sent in its max_datagram_frame_size
 transport parameter MUST terminate the connection with error
 PROTOCOL_VIOLATION.
 
+When clients use 0-RTT, they MAY store the value of the server's
+max_datagram_frame_size transport parameter. Doing so allows the client to send
+DATAGRAM frames in 0-RTT packets. When servers decide to accept 0-RTT data,
+they MUST send a max_datagram_frame_size transport parameter greater or equal
+to the value they sent to the client in the connection where they sent them
+the NewSessionTicket message. If a client stores the value of the
+max_datagram_frame_size transport parameter with their 0-RTT state, they MUST
+validate that the new value of the max_datagram_frame_size transport parameter
+sent by the server in the handshake is greater or equal to the stored value;
+if not, the client MUST terminate the connection with error PROTOCOL_VIOLATION.
+
 # Datagram Frame Type
 
 DATAGRAM frames are used to transmit application data in an unreliable manner.


### PR DESCRIPTION
Clarifies the rules for storing the max_datagram_frame_size transport parameter with 0-RTT state.

Closes #14.