### PR TITLE
Change TP from Frame Size to Payload Size

### DIFF
--- a/draft-pauly-quic-datagram.md
+++ b/draft-pauly-quic-datagram.md
@@ -128,8 +128,8 @@ transport parameter. Endpoints MUST NOT send DATAGRAM frames of size strictly
 larger than the value of max_datagram_frame_size the endpoint has received from
 its peer. An endpoint that receives a DATAGRAM frame when it has not sent the
 max_datagram_frame_size transport parameter MUST terminate the connection with
-error PROTOCOL_VIOLATION. An endpoint that receives a DATAGRAM frame that is
-strictly larger than the value it sent in its max_datagram_frame_size
+error PROTOCOL_VIOLATION. An endpoint that receives a DATAGRAM frame that has
+payload strictly larger than the value it sent in its max_datagram_frame_size
 transport parameter MUST terminate the connection with error
 PROTOCOL_VIOLATION. Endpoints that wish to use DATAGRAM frames need to ensure
 they send a max_datagram_frame_size value sufficient to allow their peer to

--- a/draft-pauly-quic-datagram.md
+++ b/draft-pauly-quic-datagram.md
@@ -120,14 +120,13 @@ Support for receiving the DATAGRAM frame types is advertised by means
 of a QUIC Transport Parameter (name=max_datagram_frame_size, value=0x0020).
 The max_datagram_frame_size transport parameter is an integer value
 (represented as a variable-length integer) that represents the maximum
-size of a DATAGRAM frame (including the frame type, length, and
-payload) the endpoint is willing to receive, in bytes. An endpoint that
-includes this parameter supports the DATAGRAM frame types and is willing to
-receive such frames on this connection. Endpoints MUST NOT send DATAGRAM
-frames until they have sent and received the max_datagram_frame_size transport
-parameter. Endpoints MUST NOT send DATAGRAM frames of size strictly larger
-than the value of max_datagram_frame_size the endpoint has received from its
-peer. An endpoint that receives a DATAGRAM frame when it has not sent the
+size of DATAGRAM payload the endpoint is willing to receive, in bytes. An
+endpoint that includes this parameter supports the DATAGRAM frame types and is
+willing to receive such frames on this connection. Endpoints MUST NOT send
+DATAGRAM frames until they have sent and received the max_datagram_frame_size
+transport parameter. Endpoints MUST NOT send DATAGRAM frames of size strictly
+larger than the value of max_datagram_frame_size the endpoint has received from
+its peer. An endpoint that receives a DATAGRAM frame when it has not sent the
 max_datagram_frame_size transport parameter MUST terminate the connection with
 error PROTOCOL_VIOLATION. An endpoint that receives a DATAGRAM frame that is
 strictly larger than the value it sent in its max_datagram_frame_size

--- a/draft-pauly-quic-datagram.md
+++ b/draft-pauly-quic-datagram.md
@@ -124,7 +124,7 @@ size of DATAGRAM payload the endpoint is willing to receive, in bytes. An
 endpoint that includes this parameter supports the DATAGRAM frame types and is
 willing to receive such frames on this connection. Endpoints MUST NOT send
 DATAGRAM frames until they have sent and received the max_datagram_frame_size
-transport parameter. Endpoints MUST NOT send DATAGRAM frames of size strictly
+transport parameter. Endpoints MUST NOT send DATAGRAM payloads of size strictly
 larger than the value of max_datagram_frame_size the endpoint has received from
 its peer. An endpoint that receives a DATAGRAM frame when it has not sent the
 max_datagram_frame_size transport parameter MUST terminate the connection with


### PR DESCRIPTION
Updates the the transport parameter to specify the maximum length of payload instead of size of the frame.

Fixes #30